### PR TITLE
fixed monkeypatch patch location in test_selection

### DIFF
--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -9,7 +9,7 @@ def test_select_smart_challenge_never_attempted(monkeypatch):
     ]
     
     # Mock database returning no attempts
-    monkeypatch.setattr("leet_helix.app.get_attempts", lambda: [])
+    monkeypatch.setattr("leet_helix.challenges.get_attempts", lambda: [])
         
     selected = select_smart_challenge(challenges)
     assert selected in challenges


### PR DESCRIPTION
test_select_smart_challenge_never_attempted incorrectly patched "leet.app.get_attempts" when it should patch "leet.challenges.get_attempts" like the other tests do