### PR TITLE
move pytest to optional-dependencies under test key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,10 @@ dependencies = [
     "rich",
     "sqlmodel",
     "sqlite-utils",
-    "pytest",
 ]
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [project.scripts]
 leet = "leet_helix.main:app"


### PR DESCRIPTION
pytest is only necessary to run tests, which is not something most users will do, so it should be an optional dependency of the program