### PR TITLE
added basic key-logging as ANSI sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "sqlmodel",
     "sqlite-utils",
     "pytest",
+    "pyntercept==0.0.21",
 ]
 
 [project.scripts]

--- a/src/leet_helix/app.py
+++ b/src/leet_helix/app.py
@@ -100,7 +100,8 @@ def play(challenge_id: str = typer.Argument(None, help="The ID of the challenge 
         try:
             start_time = time.time()
             # Open in helix
-            if not open_editor(tmp_file_path):
+            input_data = open_editor(tmp_file_path)
+            if input_data is None:
                 return
             end_time = time.time()
             

--- a/src/leet_helix/editor.py
+++ b/src/leet_helix/editor.py
@@ -1,15 +1,51 @@
 """This file encapsulates logic to working with helix editor.""" 
 
-import subprocess
+import sys
 
 from .cfg import console
 
-def open_editor(file_path):
+def open_editor_unix(file_path: str) -> list[str] | None:
+    from pyntercept.processes.process import PTYProcess
+    from pyntercept.renderers.unixRenderer import UnixRenderer
+    
+    res: list[str] = []
+    
+    def on_in_upd(data: bytes) -> bytes:        
+        res.append(data.decode() + '\n')
+        return data
+    
+    with PTYProcess(
+        ['hx', file_path], 
+        UnixRenderer(dest_raw=False),
+        src_transforms=[on_in_upd]
+    ) as pty_process:
+        while pty_process.update():
+            pass
+    
+    return res
+
+
+def open_editor_legacy(file_path: str) -> list[str] | None:
+    import subprocess
+    
+    res: list[str] = []
+    
+    subprocess.run(["hx", file_path])
+
+    return res
+
+
+def open_editor(file_path: str) -> list[str] | None:
     """Opens the file in Helix editor."""
     
     try:
-        subprocess.run(["hx", file_path])
-        return True
+        if sys.platform in ['linux', 'darwin', 'freebsd', 'android', 'ios', 'cygwin']:
+            return open_editor_unix(file_path)
+        else:
+            return open_editor_legacy(file_path)
     except FileNotFoundError:
         console.print("[red]Error: Helix editor ('hx') not found. Please install Helix.[/red]")
-        return False
+    except Exception as e:
+        console.print("[red]An error ocurred!\n" +
+            f"Please information below to the developers: https://github.com/Jarrlist/LeetHelix/issues[/red]\n{e}"
+        )


### PR DESCRIPTION
Hello, sorry I've messed up a little bit in the previous PR draft. 
 
Initially I planned more than just key-logging, I also planned to implement two panes, one for leetHelix and the other for the editor itself and even a progress bar which in real time would show the progress.

But unfortunately, I have struggled with quirks and shenanigans with a `rich` library. Some of them are fixed, and now It's working at least in one pane like before, but it's also possible to intercept data to/from child processes, and child process spawning is now non-blocking.

But I think it's better to test these functionality better. Maybe this new functionality would be available in case when the user provides an additional flag `--experimental`? 

